### PR TITLE
Feat: Recording toggle

### DIFF
--- a/hyprcap
+++ b/hyprcap
@@ -155,7 +155,9 @@ function record_start() {
 
     # Then we wait for the recording to finish. Then we can move on to
     # operations (notifications, saving, etc.)
+    Print -1 "Waiting for process $rec_pid to finish...\n"
     waitpid "$rec_pid"
+    Print -1 "Process $rec_pid finished.\n"
     local exit_code=$?
 
     # Once wf-recorder exits, we can remove the PID file
@@ -165,7 +167,19 @@ function record_start() {
 }
 
 function record_stop() {
-    NYI && exit 1 # TODO: Remove when implemented
+    Print -1 "Stopping screen recording\n"
+
+    if [ ! -r "$REC_PID_PATH" ]; then
+        Print -E "Error: No screen recording PID found.\n"
+        return 1
+    fi
+
+    local rec_pid=$(cat "$REC_PID_PATH")
+
+    if ! kill -INT "$rec_pid"; then
+        Print -E "Error: Failed to send a stop signal.\n"
+        return 1
+    fi
 }
 
 # --------------- Geometry grabbing ---------------

--- a/hyprcap
+++ b/hyprcap
@@ -1,6 +1,4 @@
 #!/usr/bin/env sh
-# TODO: Fix ctr+C not killing the recorder process (only kills the script,
-# which is actually running `waitpid`)
 
 readonly VERSION="None (not yet released)"
 
@@ -155,6 +153,11 @@ function record_start() {
     local rec_pid=$!
     echo "$rec_pid" > "$REC_PID_PATH"
 
+    # This lets the shell pass the SIGINT signal to the recording process
+    # instead of getting killed while waiting.
+    Print -1 "Setting up SIGINT trap.\n"
+    trap 'record_stop' INT
+
     # Then we wait for the recording to finish. Then we can move on to
     # operations (notifications, saving, etc.)
     Print -1 "Waiting for process $rec_pid to finish...\n"
@@ -170,6 +173,8 @@ function record_start() {
 
 function record_stop() {
     Print -1 "Stopping screen recording\n"
+
+    trap - INT # Remove the SIGINT trap
 
     if [ ! -r "$REC_PID_PATH" ]; then
         Print -E "Error: No screen recording PID found.\n"

--- a/hyprcap
+++ b/hyprcap
@@ -1,7 +1,6 @@
 #!/usr/bin/env sh
 # TODO: Fix ctr+C not killing the recorder process (only kills the script,
 # which is actually running `waitpid`)
-# TODO: Implement skipping geometry resolution for recording stop
 
 readonly VERSION="None (not yet released)"
 
@@ -768,6 +767,16 @@ args $0 "$@"
 Print -1 "Running HyprCap version $VERSION\n"
 Print -1 "Command selected: $COMMAND\n"
 
+# ---- Early exit commands ----
+if [ "$COMMAND" = "record-stop" ]; then
+    Print -1 "Stopping recording...\n"
+    if ! record_stop; then
+        Print -E "Fatal: Failed to stop screen recording.\n"
+        exit 1
+    fi
+    exit 0
+fi
+
 # ---- Init ----
 
 [ $FREEZE -eq 1 ] && freeze
@@ -815,12 +824,6 @@ case "$COMMAND" in
         CAPTURE_PATH="$CAPTURE_PATH.mp4" # Ensure the file has the right extension
         if ! record_start; then
             Print -E "Fatal: Failed to start screen recording.\n"
-            exit 1
-        fi
-        ;;
-    record-stop)
-        if ! record_stop; then
-            Print -E "Fatal: Failed to stop screen recording.\n"
             exit 1
         fi
         ;;

--- a/hyprcap
+++ b/hyprcap
@@ -40,9 +40,9 @@ https://github.com/alonso-herreros/hyprcap/issues
 
 Commands:
   shot | screenshot            Take a screenshot (default)
-! rec | record                 Toggle screen recording
-! rec-start | record-start     Start a screen recording
-! rec-stop | record-stop       Stop a screen recording
+  rec | record                 Toggle screen recording
+  rec-start | record-start     Start a screen recording
+  rec-stop | record-stop       Stop a screen recording
 
 A selection can be specified after the command, with the -m or --mode option,
 or using a dmenu-like menu if neither is specified.

--- a/hyprcap
+++ b/hyprcap
@@ -147,15 +147,21 @@ function record_start() {
         return 1
     fi
 
-    # Instead of forking, we're saving the PID of the running HyprCap. When a
-    # SIGINT arrives, it will be sent to wf-recorder and then the HyprCap will
-    # continue execution (notify, save, etc.)
-    echo "$$" > "$REC_PID_PATH"
+    # We send this to the background so we can store its PID in a file.
+    # Otherwise, we wouldn't be able to gracefully stop it from the outside.
+    wf-recorder -g "$GEOMETRY" -f "$capture_path" --overwrite --audio &
+    local rec_pid=$!
+    echo "$rec_pid" > "$REC_PID_PATH"
 
-    wf-recorder -g "$GEOMETRY" -f "$capture_path" --overwrite --audio
+    # Then we wait for the recording to finish. Then we can move on to
+    # operations (notifications, saving, etc.)
+    waitpid "$rec_pid"
+    local exit_code=$?
 
     # Once wf-recorder exits, we can remove the PID file
     rm "$REC_PID_PATH" 2>/dev/null
+    # And return the exit code from the recording command
+    return $exit_code
 }
 
 function record_stop() {

--- a/hyprcap
+++ b/hyprcap
@@ -5,6 +5,7 @@ readonly VERSION="None (not yet released)"
 # TODO: This is rather a tmp file than a cache file. Fix it?
 readonly CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/hyprcap"
 readonly CAPTURE_FILENAME="capture"
+readonly REC_PID_PATH="${XDG_RUNTIME_DIR:-/run}/hyprcap_rec.pid"
 
 readonly DEF_SCREENSHOT_DIR="${XDG_PICTURES_DIR:-$HOME/Pictures}/Screenshots"
 readonly DEF_RECORDING_DIR="${XDG_VIDEOS_DIR:-$HOME/Videos}/Captures"
@@ -35,8 +36,10 @@ Please report bugs and issues at
 https://github.com/alonso-herreros/hyprcap/issues
 
 Commands:
-  shot | screenshot        Take a screenshot (default)
-  rec | record             Take a screen recording
+  shot | screenshot            Take a screenshot (default)
+! rec | record                 Toggle screen recording
+! rec-start | record-start     Start a screen recording
+! rec-stop | record-stop       Stop a screen recording
 
 A selection can be specified after the command, with the -m or --mode option,
 or using a dmenu-like menu if neither is specified.
@@ -135,12 +138,28 @@ function screenshot() {
     grim -g "$GEOMETRY" "$capture_path"
 }
 
-function record() {
+function record_toggle() {
+    Print -1 "Toggling screen recording.\n"
+
+    if [ -r "$REC_PID_PATH" ]; then
+        Print -2 "Recording in progress found. Stopping it.\n"
+        record_stop
+    else
+        Print -2 "No recording in progress found. Starting a new one.\n"
+        record_start
+    fi
+}
+
+function record_start() {
+    Print -1 "Starting screen recording of $GEOMETRY\n"
     local capture_path="$CAPTURE_PATH"
 
-    # TODO: Support stopping an ongoing recording
 
     wf-recorder -g "$GEOMETRY" -f "$capture_path" --overwrite --audio
+}
+
+function record_stop() {
+    NYI && exit 1 # TODO: Remove when implemented
 }
 
 # --------------- Geometry grabbing ---------------
@@ -606,6 +625,12 @@ function parse_command() {
         rec | record)
             echo "record"
             ;;
+        rec-start | record-start)
+            echo "record-start"
+            ;;
+        rec-stop | record-stop)
+            echo "record-stop"
+            ;;
         *)
             Print -E "Fatal: Unknown command '$1'\n"
             exit 1
@@ -761,13 +786,24 @@ case "$COMMAND" in
             exit 1
         fi
         ;;
-    record)
+    record | record-toggle)
         # TODO: Support selecting format
         CAPTURE_PATH="$CAPTURE_PATH.mp4" # Ensure the file has the right extension
-        Print -1 "Taking a screen recording of $GEOMETRY\n"
-        if ! record; then
-            # If the recording command fails, exit with an error
-            Print -E "Fatal: Failed to take a screen recording.\n"
+        if ! record_toggle; then
+            Print -E "Fatal: Failed to toggle screen recording.\n"
+            exit 1
+        fi
+        ;;
+    record-start)
+        CAPTURE_PATH="$CAPTURE_PATH.mp4" # Ensure the file has the right extension
+        if ! record_start; then
+            Print -E "Fatal: Failed to start screen recording.\n"
+            exit 1
+        fi
+        ;;
+    record-stop)
+        if ! record_stop; then
+            Print -E "Fatal: Failed to stop screen recording.\n"
             exit 1
         fi
         ;;

--- a/hyprcap
+++ b/hyprcap
@@ -613,14 +613,15 @@ function args() {
     # use it as the selection
     [ -z "$selection" -a -n "$2" ] && selection="$2"
 
-    # If no selection is done yet, fail
+    # Handle no selection
     # TODO: Remove this when dmenu-based selection is implemented
-    if [ -z "$selection" ]; then
+    if [ -z "$selection" -a "$COMMAND" != "record-stop" ]; then
         Print -E "Fatal: No selection specified. Use --help for help.\n"
         exit 1
     fi
 
-    parse_selection "$selection" # Errors and exit if selection is invalid
+    # Parse into a standard format
+    [ -n "$selection" ] && parse_selection "$selection"
 }
 
 function parse_command() {
@@ -673,8 +674,8 @@ function parse_selection() {
             SELECTION="${selection%,*} ${selection#*,*,}"
             ;;
         *)
-            Print -E "Fatal: Unknown selection '$1'\n"
-            exit 1;;
+            Print -E "Error: Unknown selection '$1'\n"
+            return 1;;
     esac
 }
 

--- a/hyprcap
+++ b/hyprcap
@@ -1,4 +1,7 @@
 #!/usr/bin/env sh
+# TODO: Fix ctr+C not killing the recorder process (only kills the script,
+# which is actually running `waitpid`)
+# TODO: Implement skipping geometry resolution for recording stop
 
 readonly VERSION="None (not yet released)"
 

--- a/hyprcap
+++ b/hyprcap
@@ -154,8 +154,20 @@ function record_start() {
     Print -1 "Starting screen recording of $GEOMETRY\n"
     local capture_path="$CAPTURE_PATH"
 
+    if [ -r "$REC_PID_PATH" ]; then
+        Print -E "Error: Screen recording is already in progress.\n"
+        return 1
+    fi
+
+    # Instead of forking, we're saving the PID of the running HyprCap. When a
+    # SIGINT arrives, it will be sent to wf-recorder and then the HyprCap will
+    # continue execution (notify, save, etc.)
+    echo "$$" > "$REC_PID_PATH"
 
     wf-recorder -g "$GEOMETRY" -f "$capture_path" --overwrite --audio
+
+    # Once wf-recorder exits, we can remove the PID file
+    rm "$REC_PID_PATH" 2>/dev/null
 }
 
 function record_stop() {

--- a/hyprcap
+++ b/hyprcap
@@ -138,18 +138,6 @@ function screenshot() {
     grim -g "$GEOMETRY" "$capture_path"
 }
 
-function record_toggle() {
-    Print -1 "Toggling screen recording.\n"
-
-    if [ -r "$REC_PID_PATH" ]; then
-        Print -2 "Recording in progress found. Stopping it.\n"
-        record_stop
-    else
-        Print -2 "No recording in progress found. Starting a new one.\n"
-        record_start
-    fi
-}
-
 function record_start() {
     Print -1 "Starting screen recording of $GEOMETRY\n"
     local capture_path="$CAPTURE_PATH"
@@ -635,7 +623,8 @@ function parse_command() {
             echo "screenshot"
             ;;
         rec | record)
-            echo "record"
+            Print -1 "Resolving recording toggle.\n"
+            [ -f "$REC_PID_PATH" ] && echo "record-stop" || echo "record-start"
             ;;
         rec-start | record-start)
             echo "record-start"
@@ -798,15 +787,7 @@ case "$COMMAND" in
             exit 1
         fi
         ;;
-    record | record-toggle)
-        # TODO: Support selecting format
-        CAPTURE_PATH="$CAPTURE_PATH.mp4" # Ensure the file has the right extension
-        if ! record_toggle; then
-            Print -E "Fatal: Failed to toggle screen recording.\n"
-            exit 1
-        fi
-        ;;
-    record-start)
+    record | record-start)
         CAPTURE_PATH="$CAPTURE_PATH.mp4" # Ensure the file has the right extension
         if ! record_start; then
             Print -E "Fatal: Failed to start screen recording.\n"


### PR DESCRIPTION
This allows using a single keybind to start and stop recordings, as well as running a recording detached from any terminal and killing it later with a simple call to hyprcap again