### PR TITLE
feat: Print saved file path on stdout

### DIFF
--- a/hyprcap
+++ b/hyprcap
@@ -880,7 +880,10 @@ esac
 
 if [ $RAW -eq 1 ]; then
     cat "$CAPTURE_PATH"
+# If output isn't raw and --quiet isn't set, print the path to the capture
 elif [ $VERBOSE -ge 0 ]; then
+    # Prints the save path if set (when using -w, -o and/or -f), otherwise
+    # a path to the transient capture file in the cache dir.
     echo "${SAVE_PATH:-$CAPTURE_PATH}"
 fi
 

--- a/hyprcap
+++ b/hyprcap
@@ -880,7 +880,7 @@ esac
 
 if [ $RAW -eq 1 ]; then
     cat "$CAPTURE_PATH"
-else
+elif [ $VERBOSE -ge 0 ]; then
     echo "${SAVE_PATH:-$CAPTURE_PATH}"
 fi
 

--- a/hyprcap
+++ b/hyprcap
@@ -878,6 +878,12 @@ esac
 
 [ $COPY -eq 1 ] && copy_capture
 
+if [ $RAW -eq 1 ]; then
+    cat "$CAPTURE_PATH"
+else
+    echo "${SAVE_PATH:-$CAPTURE_PATH}"
+fi
+
 if [ $NOTIFY -eq 1 ]; then
     while
         action="$(notify)"
@@ -886,5 +892,3 @@ if [ $NOTIFY -eq 1 ]; then
         [ $ACTIONS -eq 1 -a -n "$action" ] && act "$action"
     do true; done
 fi
-
-[ $RAW -eq 1 ] && cat "$CAPTURE_PATH"


### PR DESCRIPTION
Closes #19.

This feature makes Hyprcap print the saved file path on stdout (only if the `--raw` option isn't set). The path is the main capture path (in the `$XDG_CACHE_HOME/hyprcap` dir), or the save path specified on the command line if set with `--write`, `--output-dir` or `--filename`.

This happens before notifications, so if the save option is selected via notification actions, it won't be reflected here.