### PR TITLE
Docs: Improve saving information in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,8 +178,16 @@ bind = $MOD SHIFT ALT, R, exec, hyprcap rec window:active -c -n
 
 ### Save location
 
-You can save the captures by using the `--write` option. The `--out-dir` and
-`--filename` options can be used to specify the output directory and filename
+You can save the captures by using the `--write` (`-w`) option. The `--out-dir`
+(`-o`) and `--filename` (`-f`) options can be used to specify the output
+directory and filename, respectively. By default, captures are saved in the
+`$XDG_PICTURES_DIR/Screenshots` directory for screenshots and
+`$XDG_VIDEOS_DIR/Captures` for recordings.
+
+> [!Note]
+>
+> The current capture is saved in the `$XDG_CACHE_DIR/hyprcap` dir for internal
+> use.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -182,7 +182,9 @@ You can save the captures by using the `--write` (`-w`) option. The `--out-dir`
 (`-o`) and `--filename` (`-f`) options can be used to specify the output
 directory and filename, respectively. By default, captures are saved in the
 `$XDG_PICTURES_DIR/Screenshots` directory for screenshots and
-`$XDG_VIDEOS_DIR/Captures` for recordings.
+`$XDG_VIDEOS_DIR/Captures` for recordings. If those XDG directory variables
+are not set, the defaults are `~/Pictures/Screenshots` and
+`~/Videos/Captures`, respectively.
 
 > [!Note]
 >


### PR DESCRIPTION
Included information about short form flags saving, as well as default save locations to the Readme.