### PR TITLE
Fix: Allow sending notification with no actions

### DIFF
--- a/hyprcap
+++ b/hyprcap
@@ -457,13 +457,23 @@ function notify() {
     [ $COPY -eq 1 ] && message+="Copied to the clipboard.\n"
     [ $SAVE -eq 1 ] && message+="Saved in <i>$SAVE_PATH</i>.\n"
 
-    local extra_args=""
-    [ $ACTIONS -eq 1 ] && extra_args=("${ACTIONS_ARGS[@]}")
+    Print -1 "Notifying for command '$COMMAND':\n$message[EOT]\n"
 
     # TODO: Create a thumbnail for video recordings
-    notify-send "$title" "$message" \
-        -t "$NOTIF_TIMEOUT" -a HyprCap -r $NOTIF_ID \
-        -i "$CAPTURE_PATH" "${extra_args[@]}"
+
+    # This function contains common notification parameters regardless of
+    # actions.
+    _notify() {
+        notify-send "$title" "$message" \
+            -t "$NOTIF_TIMEOUT" -a HyprCap -r $NOTIF_ID \
+            -i "$CAPTURE_PATH" "$@"
+    }
+
+    if [ $ACTIONS -eq 1 ]; then
+        _notify "${ACTIONS_ARGS[@]}"
+    else
+        _notify
+    fi
 }
 
 # --------------- Post-capture actions ---------------


### PR DESCRIPTION
The previous method of not duplicating the common `notify-send` code was to pass additional parameters as an optionally empty variable to the same command line. However, when empty, this variable still counted as an argument and caused `notify-send` to fail.

By using a small function that adds its own parameters to the common command line, and calling it with or without additional parameters depending on the behavior desired, this problem is fixed while avoiding duplication of that common code. Plus, a complex array-to-array assignment is skipped as well.
