### PR TITLE
Fix: `DISABLE_TITLE` was checked too early

### DIFF
--- a/hyprcap
+++ b/hyprcap
@@ -773,10 +773,6 @@ function prompt_selection() {
 
 # ---- Pre-init ----
 
-# Set terminal title. This prevents self-matching when selecting windows
-# by name
-[ $DISABLE_TITLE -ne 1 ] && [ -t 1 ] && echo -ne "\033]0;HyprCap\007"
-
 # Not with constants because it can change
 CAPTURE_PATH="$CACHE_DIR/$CAPTURE_FILENAME"
 
@@ -825,6 +821,10 @@ if [ "$COMMAND" = "record-stop" ]; then
 fi
 
 # ---- Init ----
+
+# Set terminal title. This prevents self-matching when selecting windows
+# by name
+[ $DISABLE_TITLE -ne 1 ] && [ -t 1 ] && echo -ne "\033]0;HyprCap\007"
 
 [ $FREEZE -eq 1 ] && freeze
 


### PR DESCRIPTION
The variable responsible for --disable-title wasn't set at the time of checking. Moved the title-setting code after arg parsing.