### PR TITLE
Docs: Add example for cancelled selection fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Examples:
   Screenshot a window (interactive)     `hyprcap shot window`
   Toggle recording a specific region    `hyprcap rec region:100,100,400x300`
   Stop an ongoing recording             `hyprcap rec-stop`
-  Fall back to monitor catpure when selection is cancelled
+  Fall back to monitor capture when selection is cancelled
         `hyprcap shot region || hyprcap shot monitor:active`
 
 ```

--- a/hyprcap
+++ b/hyprcap
@@ -106,7 +106,7 @@ Examples:
   Screenshot a window (interactive)     \`hyprcap shot window\`
   Toggle recording a specific region    \`hyprcap rec region:100,100,400x300\`
   Stop an ongoing recording             \`hyprcap rec-stop\`
-  Fall back to monitor catpure when selection is cancelled
+  Fall back to monitor capture when selection is cancelled
         \`hyprcap shot region || hyprcap shot monitor:active\`
 EOF
 }


### PR DESCRIPTION
As an alternative to #34, you can use the `||` shell operator to fall back to a different selection if an interactive selection (like `region`) is cancelled. This is not the first thing that comes to mind, so an example was added to the help message and its copy in the `README.md` file.
