### PR TITLE
Fix: Fully wait for wf-recorder before continuing

### DIFF
--- a/hyprcap
+++ b/hyprcap
@@ -202,6 +202,10 @@ function record_start() {
     Print -1 "Process $rec_pid finished.\n"
     local exit_code=$?
 
+    # Wait for al subprocesses to finish too, otherwise we may find
+    # incomplete files.
+    wait
+
     # Once wf-recorder exits, we can remove the PID file
     rm "$REC_PID_PATH" 2>/dev/null
     # And return the exit code from the recording command

--- a/hyprcap
+++ b/hyprcap
@@ -200,7 +200,7 @@ function record_start() {
     Print -1 "Waiting for process $rec_pid to finish...\n"
     wait "$rec_pid"
     local exit_code=$?
-    Print -1 "Process $rec_pid finished.\n"
+    Print -1 "Process $rec_pid finished with code $exit_code.\n"
 
     # Wait for al subprocesses to finish too, otherwise we may find
     # incomplete files.
@@ -208,8 +208,10 @@ function record_start() {
 
     # Once wf-recorder exits, we can remove the PID file
     rm "$REC_PID_PATH" 2>/dev/null
-    # And return the exit code from the recording command
-    return $exit_code
+    # And return the exit code from the recording command unless it's
+    # 130 (SIGINT), which is expected.
+    [ $exit_code -eq 130 ] || return $exit_code
+    # Default return code is 0 otherwise
 }
 
 function record_stop() {

--- a/hyprcap
+++ b/hyprcap
@@ -199,8 +199,8 @@ function record_start() {
     # operations (notifications, saving, etc.)
     Print -1 "Waiting for process $rec_pid to finish...\n"
     wait "$rec_pid"
-    Print -1 "Process $rec_pid finished.\n"
     local exit_code=$?
+    Print -1 "Process $rec_pid finished.\n"
 
     # Wait for al subprocesses to finish too, otherwise we may find
     # incomplete files.


### PR DESCRIPTION
Hyprcap wasn't waiting for all subprocesses of `wf-recorder` to finish before proceeding with operations that depended on its completion, like copying the file. Hyprcap itself was terminating before `wf-recorder` had fully completed its tasks.

This PR adds a wait to ensure that Hyprcap waits for all subprocesses of `wf-recorder` to finish before proceeding. Also, it fixes the exit code handling, which was previously not correctly capturing the exit status of `wf-recorder`.
