### PR TITLE
removed unnecessary notification timeout default

### DIFF
--- a/hyprcap
+++ b/hyprcap
@@ -97,7 +97,8 @@ Notification options:
                                 --notify.
   -t, --notif-timeout <time>    Notification timeout in milliseconds. Requires
                                 --notify
-                                Default: unspecified, up to your notification daemon's config
+                                Default: unspecified, up to your notification
+                                daemon's config
 
 Output options:
   -r, --raw                     Output raw capture data to stdout.


### PR DESCRIPTION
#49 

now the timeout is passed to `notify-send` only when it is explicitly set using `-t`, otherwise no timeout is passed, leaving the determination to the notification demon