### PR TITLE
Fix: Send stronger signals to hyprpicker if it persists

### DIFF
--- a/hyprcap
+++ b/hyprcap
@@ -583,13 +583,9 @@ function unfreeze() {
     if [ -n "$HYPRPICKER_PID" ]; then
         kill "$HYPRPICKER_PID"
 
-        for sig in -1 -9; do
-            if ! timeoutpid "$TIMEOUT" "$HYPRPICKER_PID" "$sig"; then
-                Print "Warning: hyprpicker still running, sent signal $sig\n"
-            else
-                break
-            fi
-        done
+        if ! timeoutpid "$TIMEOUT" "$HYPRPICKER_PID" -1; then
+            Print "Warning: hyprpicker still running, sent signal -1\n"
+        fi
 
         unset HYPRPICKER_PID
     else # In case we messed up


### PR DESCRIPTION
Fixed a problem with Hyprpicker sometimes failing to terminate, leaving the screen in a frozen state.

The function unfreeze now waits up to 5 seconds before attempting a forceful termination of Hyprpicker, leaving it with enough time to clean up.

The 5 seconds are a maximum time for termination. The loop quits as soon as Hyprpicker's PID is gone, so it won't slow down the program for other cases.

[!] This solution is ONLY a workaround. It doesn't solve the inherent problem with Hyprpicker failing to quit immediately.
    Freeze will no longer persist, but the program might take 5 seconds to terminate under some conditions.

[!] It cannot be guaranteed that 5 seconds will in all cases be sufficient for Hyprpicker's clean up process.
    Slower systems might require more time, but that should be a very rare exception.