### PR TITLE
Feat: Allow passing extra args

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ You can get help on how to use HyprCap by running `hyprcap -h`:
 
 ```
 $ hyprcap -h
-Usage: hyprcap [options...] <command> [[-s] <selection>]
+Usage: hyprcap [options...] <command> [[-s] <selection>] [-- [capturer_args]]
 
 HyprCap is a utility to easily capture screenshots and screen recordings on
 Hyprland.
@@ -108,6 +108,9 @@ Selection:
   region                    Select a region manually using 'slurp'.
   region:X,Y,WxH            Select the specified region.
 
+  * Note: Any selection will be trimmed to a single monitor when recording due
+    to limitations in 'wf-recorder'
+
 
 Selection options:
   -s, --select <selection>      Alternative way to specify the selection.
@@ -115,16 +118,25 @@ Selection options:
 Saving options:
   -w, --write                   Save the capture to a file using the default
                                 filename and directory.
+  -W, --no-write                Don't save captures to a file (default).
+  -F, --no-file                 Same as `--no-write`
   -o, --output-dir <dir>        Directory in which to save captures.
                                 Default: $XDG_PICTURES_DIR/Screenshots or
                                 $XDG_VIDEOS_DIR/Captures
   -f, --filename <filename>     The file name for the resulting capture within
-                                the output directory.
+                                the output directory. The file extension
+                                (everything after the last dot) is used to
+                                determine the file type, unless overridden with
+                                `--filetype`.
                                 Default:
                                   YYYY-MM-DD-hhmmss_hyprcap.<extension>
                                 where <extension> is determined by the command
-                                (e.g. png for screenshots, mp4 for recordings).
-  -F, --no-file                 Don't save captures to a file (default).
+                                (see the `--filetype` defaults).
+      --filetype <type>         Force a file type for the capture. For
+                                supported types, see the documentation for grim
+                                and wf-recorder.
+                                Defaults: png for screenshots, mp4 for
+                                recordings.
   -c, --copy                    Copy capture to clipboard with 'wl-copy'.
 
 Capture options:
@@ -143,7 +155,8 @@ Notification options:
                                 --notify.
   -t, --notif-timeout <time>    Notification timeout in milliseconds. Requires
                                 --notify
-                                Default: 10 seconds.
+                                Default: unspecified, up to your notification
+                                daemon's config
 
 Output options:
   -r, --raw                     Output raw capture data to stdout.
@@ -156,6 +169,11 @@ Output options:
   -V, --version                 Show the version and exit.
   -h, --help                    Show this help message and exit.
 
+Capturer arguments:
+  Any arguments passed after a double dash ('--') will be passed directly to
+  the capture program: 'grim' in the case of screenshots, or 'wf-recorder' in
+  the case of recordings.
+
 Examples:
   Toggle recording current monitor      `hyprcap rec monitor:active`
   Screenshot a window (interactive)     `hyprcap shot window`
@@ -163,7 +181,6 @@ Examples:
   Stop an ongoing recording             `hyprcap rec-stop`
   Fall back to monitor capture when selection is cancelled
         `hyprcap shot region || hyprcap shot monitor:active`
-
 ```
 
 ## Configuration

--- a/hyprcap
+++ b/hyprcap
@@ -31,7 +31,7 @@ readonly TIMEOUTPID_POLL_STEP=0.1 # Shell scripts aren't great at math
 
 function Help() {
     cat <<EOF
-Usage: hyprcap [options...] <command> [[-s] <selection>]
+Usage: hyprcap [options...] <command> [[-s] <selection>] [-- [capturer_args]]
 
 HyprCap is a utility to easily capture screenshots and screen recordings on
 Hyprland.
@@ -120,6 +120,11 @@ Output options:
                                 causing issues, e.g. when running in a script.
   -V, --version                 Show the version and exit.
   -h, --help                    Show this help message and exit.
+
+Capturer arguments:
+  Any arguments passed after a double dash ('--') will be passed directly to
+  the capture program: 'grim' in the case of screenshots, or 'wf-recorder' in
+  the case of recordings.
 
 Examples:
   Toggle recording current monitor      \`hyprcap rec monitor:active\`

--- a/hyprcap
+++ b/hyprcap
@@ -939,11 +939,12 @@ if [ -z "$1" ]; then
     exit 1
 fi
 COMMAND=$(parse_command "$1")
+shift # Clear command from current args
 
 # ~~~ Selection ~~~
 # If a selection was not specified already and there is another argument,
 # use it as the selection
-[ -z "$selection" -a -n "$2" ] && selection="$2"
+[ -z "$selection" -a -n "$1" ] && selection="$1" && shift
 
 # Parse into a standard format
 [ -n "$selection" ] && parse_selection "$selection"

--- a/hyprcap
+++ b/hyprcap
@@ -1034,14 +1034,14 @@ mkdir -p "$CACHE_DIR"
 
 case "$COMMAND" in
     screenshot)
-        if ! screenshot; then
+        if ! screenshot "$@"; then
             # If the screenshot command fails, exit with an error
             Print -F "Failed to take a screenshot.\n"
             Exit 1
         fi
         ;;
     record | record-start)
-        if ! record_start; then
+        if ! record_start "$@"; then
             Print -F "Screen recording failed.\n"
             Exit 1
         fi

--- a/hyprcap
+++ b/hyprcap
@@ -665,125 +665,7 @@ function timeoutpid() { # Usage: timeoutpid <duration> <pid> [signal]
 }
 
 
-# =============== Argument parsing ===============
-
-function args() {
-    local OPTS="s:wo:f:Fcd:znNaAt:rVqvh"
-    local LONG_OPTS="select:,"
-    LONG_OPTS+="write,output-dir:,filename:,no-file,filetype:,copy,"
-    LONG_OPTS+="delay:,freeze,"
-    LONG_OPTS+="notify,no-notify,actions,no-actions,notif-timeout:,"
-    LONG_OPTS+="raw,verbose,quiet,disable-title,version,help"
-
-    local options=$(getopt -o $OPTS --long $LONG_OPTS -- "$@")
-    eval set -- "$options"
-
-    while true; do
-        case "$1" in
-            -s | --select)
-                local selection="$2" # Parsing is done later
-                shift;;
-
-            -w | --write)
-                SAVE=1
-                ;;
-            -o | --output-dir)
-                SAVE=1
-                OUTPUT_DIR="$2"
-                shift;;
-            -f | --filename)
-                SAVE=1
-                FILENAME="$2"
-                shift;;
-            -W | --no-write | -F | --no-file)
-                SAVE=0
-                ;;
-            --filetype)
-                FILETYPE="$2"
-                shift;;
-            -c | --copy)
-                COPY=1
-                ;;
-
-            -d | --delay)
-                DELAY="$2"
-                shift;;
-            -z | --freeze)
-                FREEZE=1
-                ;;
-
-            -n | --notify)
-                NOTIFY=1
-                ;;
-            -N | --no-notify)
-                NOTIFY=0
-                ;;
-            -a | --actions)
-                ACTIONS=1
-                ;;
-            -A | --no-actions)
-                ACTIONS=0
-                ;;
-            -t | --notif-timeout)
-                NOTIF_TIMEOUT=$2
-                shift;;
-
-            -r | --raw)
-                RAW=1
-                ;;
-            --disable-title)
-                DISABLE_TITLE=1
-                ;;
-            -v | --verbose)
-                VERBOSE+=1
-                ;;
-            -q | --quiet)
-                VERBOSE=-1
-                ;;
-            -V | --version)
-                COMMAND=version
-                ;;
-            -h | --help)
-                Help
-                exit 0;;
-
-            --) # Marks the end of options
-                shift && break;;
-        esac
-        shift
-    done
-    shift # Remove the command itself from the arguments
-
-    if [ "$COMMAND" == "version" ]; then
-        Version
-        exit 0
-    fi
-
-    # -- Command --
-    # Check if a command was specified
-    if [ -z "$1" ]; then
-        Print -F "No command specified. Use --help for help.\n"
-        exit 1
-    fi
-    COMMAND=$(parse_command "$1")
-
-    # -- Selection --
-    # If a selection was not specified already and there is another argument,
-    # use it as the selection
-    [ -z "$selection" -a -n "$2" ] && selection="$2"
-
-    # Parse into a standard format
-    [ -n "$selection" ] && parse_selection "$selection"
-
-    # -- Check option compatibility --
-    case "$COMMAND" in rec*)
-        # Freeze is not compatible with recording
-        if [ $FREEZE -eq 1 ]; then
-            Print -E "Warning: Cannot freeze the screen while recording.\n"
-            FREEZE=0
-        fi
-    esac
-}
+# =============== Arg parsing helpers ============
 
 function parse_command() {
     case "$1" in
@@ -960,7 +842,119 @@ VERBOSE=0
 RAW=0
 
 # ---- Parse arguments ----
-args $0 "$@"
+OPTS="s:wo:f:Fcd:znNaAt:rVqvh"
+LONG_OPTS="select:,"
+LONG_OPTS+="write,output-dir:,filename:,no-file,filetype:,copy,"
+LONG_OPTS+="delay:,freeze,"
+LONG_OPTS+="notify,no-notify,actions,no-actions,notif-timeout:,"
+LONG_OPTS+="raw,verbose,quiet,disable-title,version,help"
+
+eval set -- "$(getopt -o $OPTS --long $LONG_OPTS -- "$@")"
+
+while true; do
+    case "$1" in
+        -s | --select)
+            local selection="$2" # Parsing is done later
+            shift;;
+
+        -w | --write)
+            SAVE=1
+            ;;
+        -o | --output-dir)
+            SAVE=1
+            OUTPUT_DIR="$2"
+            shift;;
+        -f | --filename)
+            SAVE=1
+            FILENAME="$2"
+            shift;;
+        -W | --no-write | -F | --no-file)
+            SAVE=0
+            ;;
+        --filetype)
+            FILETYPE="$2"
+            shift;;
+        -c | --copy)
+            COPY=1
+            ;;
+
+        -d | --delay)
+            DELAY="$2"
+            shift;;
+        -z | --freeze)
+            FREEZE=1
+            ;;
+
+        -n | --notify)
+            NOTIFY=1
+            ;;
+        -N | --no-notify)
+            NOTIFY=0
+            ;;
+        -a | --actions)
+            ACTIONS=1
+            ;;
+        -A | --no-actions)
+            ACTIONS=0
+            ;;
+        -t | --notif-timeout)
+            NOTIF_TIMEOUT=$2
+            shift;;
+
+        -r | --raw)
+            RAW=1
+            ;;
+        --disable-title)
+            DISABLE_TITLE=1
+            ;;
+        -v | --verbose)
+            VERBOSE+=1
+            ;;
+        -q | --quiet)
+            VERBOSE=-1
+            ;;
+        -V | --version)
+            COMMAND=version
+            ;;
+        -h | --help)
+            Help
+            exit 0;;
+
+        --) # Marks the end of options
+            shift && break;;
+    esac
+    shift
+done
+
+if [ "$COMMAND" == "version" ]; then
+    Version
+    exit 0
+fi
+
+# -- Command --
+# Check if a command was specified
+if [ -z "$1" ]; then
+    Print -F "No command specified. Use --help for help.\n"
+    exit 1
+fi
+COMMAND=$(parse_command "$1")
+
+# -- Selection --
+# If a selection was not specified already and there is another argument,
+# use it as the selection
+[ -z "$selection" -a -n "$2" ] && selection="$2"
+
+# Parse into a standard format
+[ -n "$selection" ] && parse_selection "$selection"
+
+# -- Check option compatibility --
+case "$COMMAND" in rec*)
+    # Freeze is not compatible with recording
+    if [ $FREEZE -eq 1 ]; then
+        Print -E "Warning: Cannot freeze the screen while recording.\n"
+        FREEZE=0
+    fi
+esac
 
 Print -I "Running HyprCap version $VERSION\n"
 Print -I "Command selected: $COMMAND\n"

--- a/hyprcap
+++ b/hyprcap
@@ -926,12 +926,13 @@ while true; do
     shift
 done
 
+# ~~~ Very early exit commands ~~~
 if [ "$COMMAND" == "version" ]; then
     Version
     exit 0
 fi
 
-# -- Command --
+# ~~~ Command ~~~
 # Check if a command was specified
 if [ -z "$1" ]; then
     Print -F "No command specified. Use --help for help.\n"
@@ -939,7 +940,7 @@ if [ -z "$1" ]; then
 fi
 COMMAND=$(parse_command "$1")
 
-# -- Selection --
+# ~~~ Selection ~~~
 # If a selection was not specified already and there is another argument,
 # use it as the selection
 [ -z "$selection" -a -n "$2" ] && selection="$2"
@@ -947,7 +948,7 @@ COMMAND=$(parse_command "$1")
 # Parse into a standard format
 [ -n "$selection" ] && parse_selection "$selection"
 
-# -- Check option compatibility --
+# ~~~ Check option compatibility ~~~
 case "$COMMAND" in rec*)
     # Freeze is not compatible with recording
     if [ $FREEZE -eq 1 ]; then
@@ -955,6 +956,8 @@ case "$COMMAND" in rec*)
         FREEZE=0
     fi
 esac
+
+# ---- Post-args ----
 
 Print -I "Running HyprCap version $VERSION\n"
 Print -I "Command selected: $COMMAND\n"

--- a/hyprcap
+++ b/hyprcap
@@ -962,6 +962,7 @@ esac
 
 Print -I "Running HyprCap version $VERSION\n"
 Print -I "Command selected: $COMMAND\n"
+Print -D "Additional arguments: $*\n"
 
 solve_filetype
 solve_filenames

--- a/hyprcap
+++ b/hyprcap
@@ -218,12 +218,14 @@ function check_cmd() {
 
 function screenshot() {
     Print -I "Making screenshot of $GEOMETRY\n"
+    Print -D "Additional arguments: $*\n"
 
-    grim -g "$GEOMETRY" -t "$FILETYPE" "$CAPTURE_PATH"
+    grim -g "$GEOMETRY" -t "$FILETYPE" "$@" "$CAPTURE_PATH"
 }
 
 function record_start() {
     Print -I "Starting screen recording of $GEOMETRY\n"
+    Print -D "Additional arguments: $*\n"
 
     if [ -r "$REC_PID_PATH" ]; then
         Print -E "Screen recording is already in progress.\n"
@@ -233,7 +235,7 @@ function record_start() {
     # We send this to the background so we can store its PID in a file.
     # Otherwise, we wouldn't be able to gracefully stop it from the outside.
     # Also, the filetype is determined by the filename ($CAPTURE_PATH).
-    wf-recorder -g "$GEOMETRY" -f "$CAPTURE_PATH" --overwrite --audio &
+    wf-recorder -g "$GEOMETRY" -f "$CAPTURE_PATH" --overwrite --audio "$@" &
     local rec_pid=$!
     echo "$rec_pid" > "$REC_PID_PATH"
 


### PR DESCRIPTION
Potential fix for #64.

I'm in a hurry rn so here's what Copilot had to say about this PR:

>This pull request makes several improvements to the argument parsing and command handling in the `hyprcap` script, primarily by refactoring the argument parsing logic, improving extensibility for additional arguments, and ensuring that extra arguments are passed to the underlying screenshot and recording commands.
>
> Argument parsing refactor:
>
> * The main argument parsing logic previously in the `args` function has been moved directly into the main script body, simplifying the flow and making the code easier to follow. (`hyprcap`) [[1]](diffhunk://#diff-ac14d20fbcb34936354f393d594f3d3d270086f42ba7945234523b3b81bf356cL668-R670) [[2]](diffhunk://#diff-ac14d20fbcb34936354f393d594f3d3d270086f42ba7945234523b3b81bf356cL963-R967)
>
> Support for additional arguments:
>
> * The `screenshot` and `record_start` functions now print and accept additional arguments, passing them through to the underlying `grim` and `wf-recorder` commands. This allows users to specify extra options for these tools when invoking `hyprcap`. (`hyprcap`) [[1]](diffhunk://#diff-ac14d20fbcb34936354f393d594f3d3d270086f42ba7945234523b3b81bf356cR221-R228) [[2]](diffhunk://#diff-ac14d20fbcb34936354f393d594f3d3d270086f42ba7945234523b3b81bf356cL236-R238)
> * The main command dispatch now forwards any remaining arguments to `screenshot` and `record_start`, ensuring that user-supplied arguments are not dropped. (`hyprcap`)
>
> Debugging improvements:
>
> * Additional debug messages have been added to log extra arguments provided by the user, aiding in troubleshooting and transparency. (`hyprcap`) [[1]](diffhunk://#diff-ac14d20fbcb34936354f393d594f3d3d270086f42ba7945234523b3b81bf356cR221-R228) [[2]](diffhunk://#diff-ac14d20fbcb34936354f393d594f3d3d270086f42ba7945234523b3b81bf356cL963-R967)

I'll come back later.