### PR TITLE
Refactor(nix): Idiomize flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,58 +1,21 @@
 {
   "nodes": {
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1777954456,
-        "narHash": "sha256-hGdgeU2Nk87RAuZyYjyDjFL6LK7dAZN5RE9+hrDTkDU=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "549bd84d6279f9852cae6225e372cc67fb91a4c1",
-        "type": "github"
+        "lastModified": 1779560665,
+        "narHash": "sha256-NpH8iEQ5JHv/BtUuzTEXUMDxPLetCDzIv4OxL8H7Kps=",
+        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
+        "type": "tarball",
+        "url": "https://releases.nixos.org/nixos/unstable/nixos-26.05pre1004030.64c08a7ca051/nixexprs.tar.xz"
       },
       "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
+        "type": "tarball",
+        "url": "https://channels.nixos.org/nixos-unstable/nixexprs.tar.xz"
       }
     },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -1,27 +1,85 @@
 {
   description = "HyprCap - Hyprland screenshot and recording utility";
 
-  inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    flake-utils.url = "github:numtide/flake-utils";
-  };
+  inputs.nixpkgs.url = "https://channels.nixos.org/nixos-unstable/nixexprs.tar.xz";
 
-  outputs = { self, nixpkgs, flake-utils }:
-    flake-utils.lib.eachDefaultSystem (system:
-      let
-        pkgs = import nixpkgs { inherit system; };
+  outputs =
+    { self, nixpkgs }:
+    let
+      eachSystem = nixpkgs.lib.genAttrs [
+        "x86_64-linux"
+        "aarch64-linux"
+        "aarch64-darwin"
+      ];
+    in
+    {
+      packages = eachSystem (
+        system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+        in
+        {
+          hyprcap = pkgs.callPackage (
+            {
+              lib,
+              stdenv,
+              makeBinaryWrapper,
+              wf-recorder,
+              grim,
+              slurp,
+              hyprland,
+              jq,
+              wl-clipboard,
+              hyprpicker,
+              libnotify,
+              fuzzel,
+            }:
+            stdenv.mkDerivation {
+              pname = "hyprcap";
+              version = self.shortRev or "dirty";
 
-        hyprcap = pkgs.stdenv.mkDerivation {
-          pname = "hyprcap";
-          version = "latest";
+              src = lib.cleanSource ./.;
 
-          src = self;
+              makeFlags = [ "PREFIX=${placeholder "out"}" ];
 
-          nativeBuildInputs = [
-            pkgs.makeWrapper
-          ];
+              nativeBuildInputs = [ makeBinaryWrapper ];
 
-          buildInputs = with pkgs; [
+              postBuild = ''
+                wrapProgram $out/bin/hyprcap \
+                  --prefix "PATH" ":" "${
+                    lib.makeBinPath [
+                      wf-recorder
+                      grim
+                      slurp
+                      hyprland
+                      jq
+                      wl-clipboard
+                      hyprpicker
+                      libnotify
+                      fuzzel
+                    ]
+                  }"
+              '';
+              meta = {
+                description = "Screenshot and recording utility for Hyprland";
+                homepage = "https://github.com/alonso-herreros/hyprcap";
+                license = lib.licenses.mit;
+                platforms = lib.platforms.linux;
+                mainProgram = "hyprcap";
+              };
+            }
+          ) { };
+          default = self.packages.${system}.hyprcap;
+        }
+      );
+      devShells = eachSystem (
+        system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+        in
+        pkgs.mkShell {
+          inputsFrom = [ self.packages.${system}.hyprcap ];
+          packages = with pkgs; [
             wf-recorder
             grim
             slurp
@@ -32,49 +90,7 @@
             libnotify
             fuzzel
           ];
-
-          # upstream build system
-          buildPhase = ''
-            runHook preBuild
-            make all
-            runHook postBuild
-          '';
-
-          installPhase = ''
-            runHook preInstall
-
-            make install PREFIX=$out
-
-            wrapProgram $out/bin/hyprcap \
-              --prefix PATH : ${pkgs.lib.makeBinPath [
-                pkgs.wf-recorder
-                pkgs.grim
-                pkgs.slurp
-                pkgs.hyprland
-                pkgs.jq
-                pkgs.wl-clipboard
-                pkgs.hyprpicker
-                pkgs.libnotify
-                pkgs.fuzzel
-              ]}
-
-            runHook postInstall
-          '';
-
-          meta = with pkgs.lib; {
-            description = "Screenshot and recording utility for Hyprland";
-            homepage = "https://github.com/alonso-herreros/hyprcap";
-            license = licenses.mit;
-            platforms = platforms.linux;
-            mainProgram = "hyprcap";
-          };
-        };
-
-      in {
-        packages.default = hyprcap;
-
-        devShells.default = pkgs.mkShell {
-          packages = [ hyprcap ];
-        };
-      });
+        }
+      );
+    };
 }


### PR DESCRIPTION
stumbled upon this repo, found the flake with some common issues. and was bored so i made a PR:

cleaned up the build instructions
used inputsFrom for the devShell so you can actually build hyprcap in it (if you just want hyprcap in a shell use `nix shell`
[used callPackage](https://nix.dev/tutorials/callpackage.html)
[stopped using flake-utils](https://ayats.org/blog/no-flake-utils)