### PR TITLE
fix(notify): Hide 'Edit' action

### DIFF
--- a/hyprcap
+++ b/hyprcap
@@ -539,8 +539,8 @@ function trim_to_monitor() {
 readonly ACTIONS_ARGS=(
     "-A" "default=Save to file"
     "-A" "copy=Copy to clipboard"
-    "-A" "edit=Edit"
 )
+    # "-A" "edit=Edit"
 function notify() {
     NOTIFY=1 # In case it was called for other reasons???
 


### PR DESCRIPTION
As mentioned in #63, this button is curently dead, as there's no edit action implemented yet. This button is best left out until the action gets implemented.